### PR TITLE
feat: adds clickhouse-connect

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-superset plugin for `Tutor <https://docs.tutor.overhang.io>`__
+Superset plugin for `Tutor <https://docs.tutor.overhang.io>`__
 ===================================================================================
 
 Installation
@@ -6,7 +6,7 @@ Installation
 
 ::
 
-    pip install git+https://github.com/open-craft/tutor-contrib-superset
+    pip install git+https://github.com/openedx/tutor-contrib-superset
 
 Usage
 -----

--- a/tutorsuperset/templates/superset/apps/docker/requirements-local.txt
+++ b/tutorsuperset/templates/superset/apps/docker/requirements-local.txt
@@ -1,2 +1,3 @@
 authlib  # OAuth2
 mysqlclient
+clickhouse-connect>0.5,<0.6


### PR DESCRIPTION
Adds `clickhouse-connect` python dependency so we can add Clickhouse as a data source.

Pins the version of `clickhouse-connect` to 0.5x, because they seem to make breaking changes with each minor release (cf https://github.com/openedx/xapi-db-load/pull/1#discussion_r1094599921).

**Dependencies**

* Setup requires https://github.com/openedx/tutor-contrib-clickhouse/pull/1

**Related discussions**

* Part of implementing https://github.com/openedx/openedx-oars/issues/30

**Testing instructions**

1. Follow [README](https://github.com/open-craft/tutor-contrib-superset#superset-plugin-for-tutor) to install this plugin.
2. Follow the testing instructions for [tutor-contrib-clickhouse#1](https://github.com/openedx/tutor-contrib-clickhouse/pull/1) to run that plugin too and load the demo xAPI data.
4. Login to [Superset](http://local.overhang.io:8088) via Open edX SSO as a superuser.
5. Add a new database connection to the `clickhouse_service:8123` using the `ch_report` credentials (ref [Superset: using Database Connections UI](https://superset.apache.org/docs/databases/db-connection-ui)):
  ![add_database](https://user-images.githubusercontent.com/7556571/217119434-c3d44f4b-e134-4508-8172-9c9e38259711.png)
  ![clickhouse_connect](https://user-images.githubusercontent.com/7556571/217119479-ca18f440-77dc-41d5-96ef-032d1ac259dc.png)
6. Add a new dataset for the `xapi.xapi_events_all` table (ref [Superset: Registering a new table](https://superset.apache.org/docs/creating-charts-dashboards/creating-your-first-dashboard/#registering-a-new-table)).