### PR TITLE
Fixes and documents authorization issue and makes the row limit configurable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,32 @@ Connect to Superset's UI on the configured port (default is `:8088`):
   http://local.overhang.io:8088
 
 
+Access and Permissions
+----------------------
+
+Superset is configured to use Open edX SSO for authentication, and the global Open edX user permissions and course access for authorization.
+
+* Users who are "superusers" in Open edX are made members of the built-in Superset `Admin`_ role, and the custom `Open edX` role.
+* Users who are global "staff" in Open edX are made members of the built-in Superset `Alpha`_ role, the custom `Open edX` role.
+* Users who have staff access to any courses in Open edX are made members of the built-in Superset `Gamma`_ role, the custom `Open edX` role.
+* All other users, including anonymous users, are not made members of any roles, and so cannot see or change any data in Superset.
+
+There is also an `Admin`_ user with a randomly-generated username and password which can access the Superset API, but cannot login to the GUI.
+
+Open edX role
+^^^^^^^^^^^^^
+
+The custom ``Open edX`` role controls access to course data using `Row Level Security Filters`_ managed by the `OARS`_ plugin.
+
+`Admin`_ and `Alpha`_ users can see data from any course, but `Gamma`_ users can only see data from courses they have staff access to.
+
+
+.. _Admin: https://superset.apache.org/docs/security/#admin
+.. _Alpha: https://superset.apache.org/docs/security/#alpha
+.. _Gamma: https://superset.apache.org/docs/security/#gamma
+.. _Row Level Security Filters: https://superset.apache.org/docs/security/#row-level-security
+.. _OARS: https://github.com/openedx/tutor-contrib-oars
+
 License
 -------
 

--- a/tutorsuperset/plugin.py
+++ b/tutorsuperset/plugin.py
@@ -31,6 +31,8 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         ("SUPERSET_OPENEDX_USER_PROFILE_PATH", "/api/user/v1/accounts/{username}"),
         ("SUPERSET_OPENEDX_COURSES_LIST_PATH", "/api/courses/v1/courses/?permissions={permission}&username={username}"),
         ("SUPERSET_OPENEDX_ROLE_NAME", "Open edX"),
+        # Set to 0 to have no row limit.
+        ("SUPERSET_ROW_LIMIT", 100_000),
     ]
 )
 

--- a/tutorsuperset/templates/superset/apps/pythonpath/openedx_sso_security_manager.py
+++ b/tutorsuperset/templates/superset/apps/pythonpath/openedx_sso_security_manager.py
@@ -65,7 +65,7 @@ class OpenEdxSsoSecurityManager(SupersetSecurityManager):
         """
         user_access = _fetch_openedx_user_access(username)
         if user_access.is_superuser:
-            return ["admin", "alpha", "openedx"]
+            return ["admin", "openedx"]
         elif user_access.is_staff:
             return ["alpha", "openedx"]
         else:

--- a/tutorsuperset/templates/superset/apps/pythonpath/superset_config_docker.py
+++ b/tutorsuperset/templates/superset/apps/pythonpath/superset_config_docker.py
@@ -6,6 +6,10 @@ from flask_appbuilder.security.manager import AUTH_OAUTH
 
 SECRET_KEY = os.environ["SECRET_KEY"]
 
+# Don't limit the number of rows that can be used in queries
+ROW_LIMIT = int({{ SUPERSET_ROW_LIMIT }})
+SQL_MAX_ROW = ROW_LIMIT
+
 # Credentials for connecting to the Open edX MySQL database
 OPENEDX_DATABASE = {
     'host': os.environ["OPENEDX_MYSQL_HOST"],


### PR DESCRIPTION
Adds a few critical fixes to the Superset plugin:

* Adds `SUPERSET_ROW_LIMIT`, which lets you configure how many rows will be queried to display chart data.
  Set to `0` if you don't want a limit (but beware the performance implications).
* Fixes a bug with `Admin`-level superusers by removing them from the `Alpha` role. This was preventing superusers from modifying anyone's Dashboards and Charts.
* Updates README to explain the authentication and authorization rights available to Superset SSO users.

Relates to https://github.com/openedx/data-wg/issues/26