### PR TITLE
refactor!: Move admin user back to superset plugin

### DIFF
--- a/tutorsuperset/plugin.py
+++ b/tutorsuperset/plugin.py
@@ -45,6 +45,8 @@ hooks.Filters.CONFIG_UNIQUE.add_items(
         ("SUPERSET_DB_PASSWORD", "{{ 24|random_string }}"),
         ("SUPERSET_OAUTH2_CLIENT_ID", "{{ 16|random_string }}"),
         ("SUPERSET_OAUTH2_CLIENT_SECRET", "{{ 16|random_string }}"),
+        ("SUPERSET_ADMIN_USERNAME", "{{ 12|random_string }}"),
+        ("SUPERSET_ADMIN_PASSWORD", "{{ 24|random_string }}"),
     ]
 )
 


### PR DESCRIPTION
Moving this back from OARS, since I think we want the service to be able to work standalone without OARS? Removal is here: https://github.com/openedx/tutor-contrib-oars/pull/8