### PR TITLE
fix: allow Course Staff to view all datasets

### DIFF
--- a/tutorsuperset/templates/superset/apps/data/roles.json
+++ b/tutorsuperset/templates/superset/apps/data/roles.json
@@ -3214,6 +3214,14 @@
       },
       {
         "permission":{
+          "name":"all_datasource_access"
+        },
+        "view_menu":{
+          "name":"all_datasource_access"
+        }
+      },
+      {
+        "permission":{
           "name":"can_get"
         },
         "view_menu":{

--- a/tutorsuperset/templates/superset/jobs/init/init-superset.sh
+++ b/tutorsuperset/templates/superset/jobs/init/init-superset.sh
@@ -27,7 +27,7 @@ set -e
 #
 /usr/bin/env bash /app/docker/docker-bootstrap.sh
 
-STEP_CNT=2
+STEP_CNT=3
 
 echo_step() {
 cat <<EOF


### PR DESCRIPTION
Adds a missing permission which allows Course Staff to view all datasets. Course Staff (aka Gamma role members) can view existing datasets, but they cannot create new ones.

Also fixes a tiny typo in the init-superset script.

cf https://github.com/openedx/openedx-oars/issues/30