### PR TITLE
fix: remove port from oauth when https is enabled

### DIFF
--- a/tutorsuperset/templates/superset/jobs/init/init-openedx.sh
+++ b/tutorsuperset/templates/superset/jobs/init/init-openedx.sh
@@ -2,7 +2,7 @@
 ./manage.py lms manage_user superset superset@apache
 ./manage.py lms create_dot_application \
     --grant-type authorization-code \
-    --redirect-uris "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ SUPERSET_HOST }}:{{ SUPERSET_PORT }}/oauth-authorized/openedxsso" \
+    --redirect-uris "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ SUPERSET_HOST }}{% if not ENABLE_HTTPS %}:{{SUPERSET_PORT}}{% else %}http{% endif %}/oauth-authorized/openedxsso" \
     --client-id {{ SUPERSET_OAUTH2_CLIENT_ID }} \
     --client-secret {{ SUPERSET_OAUTH2_CLIENT_SECRET }} \
     --scopes "user_id" \


### PR DESCRIPTION
This PR fixes an issue in which the TPA for superset-lms didn't work when all services are running on HTTPS