### PR TITLE
feat: add k8s related files

### DIFF
--- a/tutorsuperset/patches/k8s-deployments
+++ b/tutorsuperset/patches/k8s-deployments
@@ -182,10 +182,6 @@ spec:
             - name: OPENEDX_LMS_ROOT_URL
               value: "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ LMS_HOST }}"
           image: apache/superset:{{ SUPERSET_TAG }}
-          livenessProbe:
-            exec:
-              command:
-                - celery inspect ping -A superset.tasks.celery_app:app -d celery@$HOSTNAME
           name: superset-worker
           ports:
             - containerPort: {{ SUPERSET_PORT }}

--- a/tutorsuperset/patches/k8s-deployments
+++ b/tutorsuperset/patches/k8s-deployments
@@ -17,8 +17,10 @@ spec:
         app.kubernetes.io/name: superset
     spec:
       containers:
-        - name: superset
-          image: apache/superset:{{ SUPERSET_TAG }}
+        - args:
+            - bash
+            - /app/docker/docker-bootstrap.sh
+            - app-gunicorn
           env:
             - name: DATABASE_DIALECT
               value: {{ SUPERSET_DB_DIALECT }}
@@ -76,9 +78,28 @@ spec:
               value: "{{ SUPERSET_OPENEDX_COURSES_LIST_PATH }}"
             - name: OPENEDX_LMS_ROOT_URL
               value: "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ LMS_HOST }}"
-          command: ["bash", "/app/docker/docker-bootstrap.sh", "app-gunicorn"]
+          image: apache/superset:{{ SUPERSET_TAG }}
+          name: superset
           ports:
             - containerPort: {{ SUPERSET_PORT }}
+          volumeMounts:
+            - mountPath: /app/docker
+              name: docker
+            - mountPath: /app/pythonpath
+              name: pythonpath
+            - mountPath: /app/data
+              name: data
+      restartPolicy: Always
+      volumes:
+        - name: docker
+          configMap:
+            name: superset-docker
+        - name: pythonpath
+          configMap:
+            name: superset-pythonpath
+        - name: data
+          configMap:
+            name: superset-data
 
 ---
 apiVersion: apps/v1
@@ -99,8 +120,10 @@ spec:
         app.kubernetes.io/name: superset-worker
     spec:
       containers:
-        - name: superset-worker
-          image: apache/superset:{{ SUPERSET_TAG }}
+        - args:
+            - bash
+            - /app/docker/docker-bootstrap.sh
+            - worker
           env:
             - name: DATABASE_DIALECT
               value: {{ SUPERSET_DB_DIALECT }}
@@ -158,6 +181,29 @@ spec:
               value: "{{ SUPERSET_OPENEDX_COURSES_LIST_PATH }}"
             - name: OPENEDX_LMS_ROOT_URL
               value: "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ LMS_HOST }}"
-          command: ["bash", "/app/docker/docker-bootstrap.sh", "worker"]
+          image: apache/superset:{{ SUPERSET_TAG }}
+          livenessProbe:
+            exec:
+              command:
+                - celery inspect ping -A superset.tasks.celery_app:app -d celery@$HOSTNAME
+          name: superset-worker
           ports:
             - containerPort: {{ SUPERSET_PORT }}
+          volumeMounts:
+            - mountPath: /app/docker
+              name: docker
+            - mountPath: /app/pythonpath
+              name: pythonpath
+            - mountPath: /app/data
+              name: data
+      restartPolicy: Always
+      volumes:
+        - name: docker
+          configMap:
+            name: superset-docker
+        - name: pythonpath
+          configMap:
+            name: superset-pythonpath
+        - name: data
+          configMap:
+            name: superset-data

--- a/tutorsuperset/patches/k8s-deployments
+++ b/tutorsuperset/patches/k8s-deployments
@@ -23,49 +23,49 @@ spec:
             - app-gunicorn
           env:
             - name: DATABASE_DIALECT
-              value: {{ SUPERSET_DB_DIALECT }}
+              value: "{{ SUPERSET_DB_DIALECT }}"
             - name: DATABASE_HOST 
-              value: {{ SUPERSET_DB_HOST }}
+              value: "{{ SUPERSET_DB_HOST }}"
             - name: DATABASE_PORT
-              value: {{ SUPERSET_DB_PORT }}
+              value: "{{ SUPERSET_DB_PORT }}"
             - name: DATABASE_DB
-              value: {{ SUPERSET_DB_NAME }}
+              value: "{{ SUPERSET_DB_NAME }}"
             - name: DATABASE_PASSWORD
-              value: {{ SUPERSET_DB_PASSWORD }}
+              value: "{{ SUPERSET_DB_PASSWORD }}"
             - name: DATABASE_USER
-              value: {{ SUPERSET_DB_USERNAME }}
+              value: "{{ SUPERSET_DB_USERNAME }}"
             - name: OPENEDX_MYSQL_HOST
-              value: {{ MYSQL_HOST }}
+              value: "{{ MYSQL_HOST }}"
             - name: OPENEDX_MYSQL_PORT
-              value: {{ MYSQL_PORT }}
+              value: "{{ MYSQL_PORT }}"
             - name: OPENEDX_MYSQL_DATABASE
-              value: {{ OPENEDX_MYSQL_DATABASE }}
+              value: "{{ OPENEDX_MYSQL_DATABASE }}"
             - name: OPENEDX_MYSQL_USERNAME
-              value: {{ OPENEDX_MYSQL_USERNAME }}
+              value: "{{ OPENEDX_MYSQL_USERNAME }}"
             - name: OPENEDX_MYSQL_PASSWORD
-              value: {{ OPENEDX_MYSQL_PASSWORD }}
+              value: "{{ OPENEDX_MYSQL_PASSWORD }}"
             - name: OAUTH2_CLIENT_ID
-              value: {{ SUPERSET_OAUTH2_CLIENT_ID }}
+              value: "{{ SUPERSET_OAUTH2_CLIENT_ID }}"
             - name: OAUTH2_CLIENT_SECRET
-              value: {{ SUPERSET_OAUTH2_CLIENT_SECRET }}
+              value: "{{ SUPERSET_OAUTH2_CLIENT_SECRET }}"
             - name: SECRET_KEY
-              value: {{ SUPERSET_SECRET_KEY }}
+              value: "{{ SUPERSET_SECRET_KEY }}"
             - name: PYTHONPATH
-              value: /app/pythonpath:/app/docker/pythonpath_dev
+              value: "/app/pythonpath:/app/docker/pythonpath_dev"
             - name: REDIS_HOST
-              value: {{ REDIS_HOST }}
+              value: "{{ REDIS_HOST }}"
             - name: REDIS_PORT
-              value: {{ REDIS_PORT }}
+              value: "{{ REDIS_PORT }}"
             - name: REDIS_PASSWORD
-              value: {{ REDIS_PASSWORD }}
+              value: "{{ REDIS_PASSWORD }}"
             - name: FLASK_ENV
-              value: production
+              value: "production"
             - name: SUPERSET_ENV
-              value: production
+              value: "production"
             - name: SUPERSET_HOST
-              value: {{ SUPERSET_HOST }}
+              value: "{{ SUPERSET_HOST }}"
             - name: SUPERSET_PORT
-              value: {{ SUPERSET_PORT }}
+              value: "{{ SUPERSET_PORT }}"
             - name: OAUTH2_ACCESS_TOKEN_PATH
               value: "{{ SUPERSET_OAUTH2_ACCESS_TOKEN_PATH }}"
             - name: OAUTH2_AUTHORIZE_PATH

--- a/tutorsuperset/patches/k8s-deployments
+++ b/tutorsuperset/patches/k8s-deployments
@@ -1,0 +1,163 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: superset
+  labels:
+    app.kubernetes.io/name: superset
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: superset
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: superset
+    spec:
+      containers:
+        - name: superset
+          image: apache/superset:{{ SUPERSET_TAG }}
+          env:
+            - name: DATABASE_DIALECT
+              value: {{ SUPERSET_DB_DIALECT }}
+            - name: DATABASE_HOST 
+              value: {{ SUPERSET_DB_HOST }}
+            - name: DATABASE_PORT
+              value: {{ SUPERSET_DB_PORT }}
+            - name: DATABASE_DB
+              value: {{ SUPERSET_DB_NAME }}
+            - name: DATABASE_PASSWORD
+              value: {{ SUPERSET_DB_PASSWORD }}
+            - name: DATABASE_USER
+              value: {{ SUPERSET_DB_USERNAME }}
+            - name: OPENEDX_MYSQL_HOST
+              value: {{ MYSQL_HOST }}
+            - name: OPENEDX_MYSQL_PORT
+              value: {{ MYSQL_PORT }}
+            - name: OPENEDX_MYSQL_DATABASE
+              value: {{ OPENEDX_MYSQL_DATABASE }}
+            - name: OPENEDX_MYSQL_USERNAME
+              value: {{ OPENEDX_MYSQL_USERNAME }}
+            - name: OPENEDX_MYSQL_PASSWORD
+              value: {{ OPENEDX_MYSQL_PASSWORD }}
+            - name: OAUTH2_CLIENT_ID
+              value: {{ SUPERSET_OAUTH2_CLIENT_ID }}
+            - name: OAUTH2_CLIENT_SECRET
+              value: {{ SUPERSET_OAUTH2_CLIENT_SECRET }}
+            - name: SECRET_KEY
+              value: {{ SUPERSET_SECRET_KEY }}
+            - name: PYTHONPATH
+              value: /app/pythonpath:/app/docker/pythonpath_dev
+            - name: REDIS_HOST
+              value: {{ REDIS_HOST }}
+            - name: REDIS_PORT
+              value: {{ REDIS_PORT }}
+            - name: REDIS_PASSWORD
+              value: {{ REDIS_PASSWORD }}
+            - name: FLASK_ENV
+              value: production
+            - name: SUPERSET_ENV
+              value: production
+            - name: SUPERSET_HOST
+              value: {{ SUPERSET_HOST }}
+            - name: SUPERSET_PORT
+              value: {{ SUPERSET_PORT }}
+            - name: OAUTH2_ACCESS_TOKEN_PATH
+              value: "{{ SUPERSET_OAUTH2_ACCESS_TOKEN_PATH }}"
+            - name: OAUTH2_AUTHORIZE_PATH
+              value: "{{ SUPERSET_OAUTH2_AUTHORIZE_PATH }}"
+            - name: OPENEDX_USERNAME_PATH
+              value: "{{ SUPERSET_OPENEDX_USERNAME_PATH }}"
+            - name: OPENEDX_USER_PROFILE_PATH
+              value: "{{ SUPERSET_OPENEDX_USER_PROFILE_PATH }}"
+            - name: OPENEDX_COURSES_LIST_PATH
+              value: "{{ SUPERSET_OPENEDX_COURSES_LIST_PATH }}"
+            - name: OPENEDX_LMS_ROOT_URL
+              value: "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ LMS_HOST }}"
+          command: ["bash", "/app/docker/docker-bootstrap.sh", "app-gunicorn"]
+          ports:
+            - containerPort: {{ SUPERSET_PORT }}
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: superset-worker
+  labels:
+    app.kubernetes.io/name: superset-worker
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: superset-worker
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: superset-worker
+    spec:
+      containers:
+        - name: superset-worker
+          image: apache/superset:{{ SUPERSET_TAG }}
+          env:
+            - name: DATABASE_DIALECT
+              value: {{ SUPERSET_DB_DIALECT }}
+            - name: DATABASE_HOST 
+              value: {{ SUPERSET_DB_HOST }}
+            - name: DATABASE_PORT
+              value: {{ SUPERSET_DB_PORT }}
+            - name: DATABASE_DB
+              value: {{ SUPERSET_DB_NAME }}
+            - name: DATABASE_PASSWORD
+              value: {{ SUPERSET_DB_PASSWORD }}
+            - name: DATABASE_USER
+              value: {{ SUPERSET_DB_USERNAME }}
+            - name: OPENEDX_MYSQL_HOST
+              value: {{ MYSQL_HOST }}
+            - name: OPENEDX_MYSQL_PORT
+              value: {{ MYSQL_PORT }}
+            - name: OPENEDX_MYSQL_DATABASE
+              value: {{ OPENEDX_MYSQL_DATABASE }}
+            - name: OPENEDX_MYSQL_USERNAME
+              value: {{ OPENEDX_MYSQL_USERNAME }}
+            - name: OPENEDX_MYSQL_PASSWORD
+              value: {{ OPENEDX_MYSQL_PASSWORD }}
+            - name: OAUTH2_CLIENT_ID
+              value: {{ SUPERSET_OAUTH2_CLIENT_ID }}
+            - name: OAUTH2_CLIENT_SECRET
+              value: {{ SUPERSET_OAUTH2_CLIENT_SECRET }}
+            - name: SECRET_KEY
+              value: {{ SUPERSET_SECRET_KEY }}
+            - name: PYTHONPATH
+              value: /app/pythonpath:/app/docker/pythonpath_dev
+            - name: REDIS_HOST
+              value: {{ REDIS_HOST }}
+            - name: REDIS_PORT
+              value: {{ REDIS_PORT }}
+            - name: REDIS_PASSWORD
+              value: {{ REDIS_PASSWORD }}
+            - name: FLASK_ENV
+              value: production
+            - name: SUPERSET_ENV
+              value: production
+            - name: SUPERSET_HOST
+              value: {{ SUPERSET_HOST }}
+            - name: SUPERSET_PORT
+              value: {{ SUPERSET_PORT }}
+            - name: OAUTH2_ACCESS_TOKEN_PATH
+              value: "{{ SUPERSET_OAUTH2_ACCESS_TOKEN_PATH }}"
+            - name: OAUTH2_AUTHORIZE_PATH
+              value: "{{ SUPERSET_OAUTH2_AUTHORIZE_PATH }}"
+            - name: OPENEDX_USERNAME_PATH
+              value: "{{ SUPERSET_OPENEDX_USERNAME_PATH }}"
+            - name: OPENEDX_USER_PROFILE_PATH
+              value: "{{ SUPERSET_OPENEDX_USER_PROFILE_PATH }}"
+            - name: OPENEDX_COURSES_LIST_PATH
+              value: "{{ SUPERSET_OPENEDX_COURSES_LIST_PATH }}"
+            - name: OPENEDX_LMS_ROOT_URL
+              value: "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ LMS_HOST }}"
+          command: ["bash", "/app/docker/docker-bootstrap.sh", "worker"]
+          ports:
+            - containerPort: {{ SUPERSET_PORT }}

--- a/tutorsuperset/patches/k8s-deployments
+++ b/tutorsuperset/patches/k8s-deployments
@@ -126,49 +126,49 @@ spec:
             - worker
           env:
             - name: DATABASE_DIALECT
-              value: {{ SUPERSET_DB_DIALECT }}
+              value: "{{ SUPERSET_DB_DIALECT }}"
             - name: DATABASE_HOST 
-              value: {{ SUPERSET_DB_HOST }}
+              value: "{{ SUPERSET_DB_HOST }}"
             - name: DATABASE_PORT
-              value: {{ SUPERSET_DB_PORT }}
+              value: "{{ SUPERSET_DB_PORT }}"
             - name: DATABASE_DB
-              value: {{ SUPERSET_DB_NAME }}
+              value: "{{ SUPERSET_DB_NAME }}"
             - name: DATABASE_PASSWORD
-              value: {{ SUPERSET_DB_PASSWORD }}
+              value: "{{ SUPERSET_DB_PASSWORD }}"
             - name: DATABASE_USER
-              value: {{ SUPERSET_DB_USERNAME }}
+              value: "{{ SUPERSET_DB_USERNAME }}"
             - name: OPENEDX_MYSQL_HOST
-              value: {{ MYSQL_HOST }}
+              value: "{{ MYSQL_HOST }}"
             - name: OPENEDX_MYSQL_PORT
-              value: {{ MYSQL_PORT }}
+              value: "{{ MYSQL_PORT }}"
             - name: OPENEDX_MYSQL_DATABASE
-              value: {{ OPENEDX_MYSQL_DATABASE }}
+              value: "{{ OPENEDX_MYSQL_DATABASE }}"
             - name: OPENEDX_MYSQL_USERNAME
-              value: {{ OPENEDX_MYSQL_USERNAME }}
+              value: "{{ OPENEDX_MYSQL_USERNAME }}"
             - name: OPENEDX_MYSQL_PASSWORD
-              value: {{ OPENEDX_MYSQL_PASSWORD }}
+              value: "{{ OPENEDX_MYSQL_PASSWORD }}"
             - name: OAUTH2_CLIENT_ID
-              value: {{ SUPERSET_OAUTH2_CLIENT_ID }}
+              value: "{{ SUPERSET_OAUTH2_CLIENT_ID }}"
             - name: OAUTH2_CLIENT_SECRET
-              value: {{ SUPERSET_OAUTH2_CLIENT_SECRET }}
+              value: "{{ SUPERSET_OAUTH2_CLIENT_SECRET }}"
             - name: SECRET_KEY
-              value: {{ SUPERSET_SECRET_KEY }}
+              value: "{{ SUPERSET_SECRET_KEY }}"
             - name: PYTHONPATH
-              value: /app/pythonpath:/app/docker/pythonpath_dev
+              value: "/app/pythonpath:/app/docker/pythonpath_dev"
             - name: REDIS_HOST
-              value: {{ REDIS_HOST }}
+              value: "{{ REDIS_HOST }}"
             - name: REDIS_PORT
-              value: {{ REDIS_PORT }}
+              value: "{{ REDIS_PORT }}"
             - name: REDIS_PASSWORD
-              value: {{ REDIS_PASSWORD }}
+              value: "{{ REDIS_PASSWORD }}"
             - name: FLASK_ENV
-              value: production
+              value: "production"
             - name: SUPERSET_ENV
-              value: production
+              value: "production"
             - name: SUPERSET_HOST
-              value: {{ SUPERSET_HOST }}
+              value: "{{ SUPERSET_HOST }}"
             - name: SUPERSET_PORT
-              value: {{ SUPERSET_PORT }}
+              value: "{{ SUPERSET_PORT }}"
             - name: OAUTH2_ACCESS_TOKEN_PATH
               value: "{{ SUPERSET_OAUTH2_ACCESS_TOKEN_PATH }}"
             - name: OAUTH2_AUTHORIZE_PATH

--- a/tutorsuperset/patches/k8s-jobs
+++ b/tutorsuperset/patches/k8s-jobs
@@ -1,0 +1,14 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: superset-job
+  labels:
+    app.kubernetes.io/component: job
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: superset
+        image: apache/superset:{{ SUPERSET_TAG }}

--- a/tutorsuperset/patches/k8s-jobs
+++ b/tutorsuperset/patches/k8s-jobs
@@ -68,24 +68,7 @@ spec:
           - name: OPENEDX_COURSES_LIST_PATH
             value: "{{ SUPERSET_OPENEDX_COURSES_LIST_PATH }}"
           - name: OPENEDX_LMS_ROOT_URL
-            value: "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ LMS_HOST }}"
-        volumeMounts:
-            - mountPath: /app/docker
-              name: docker
-            - mountPath: /app/pythonpath
-              name: pythonpath
-            - mountPath: /app/data
-              name: data
-      volumes:
-        - name: docker
-          configMap:
-            name: superset-docker
-        - name: pythonpath
-          configMap:
-            name: superset-pythonpath
-        - name: data
-          configMap:
-            name: superset-data    
+            value: "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ LMS_HOST }}" 
 
 ---
 apiVersion: batch/v1
@@ -158,20 +141,3 @@ spec:
             value: "{{ SUPERSET_OPENEDX_COURSES_LIST_PATH }}"
           - name: OPENEDX_LMS_ROOT_URL
             value: "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ LMS_HOST }}"
-        volumeMounts:
-            - mountPath: /app/docker
-              name: docker
-            - mountPath: /app/pythonpath
-              name: pythonpath
-            - mountPath: /app/data
-              name: data
-      volumes:
-        - name: docker
-          configMap:
-            name: superset-docker
-        - name: pythonpath
-          configMap:
-            name: superset-pythonpath
-        - name: data
-          configMap:
-            name: superset-data

--- a/tutorsuperset/patches/k8s-jobs
+++ b/tutorsuperset/patches/k8s-jobs
@@ -12,6 +12,81 @@ spec:
       containers:
       - name: superset
         image: apache/superset:{{ SUPERSET_TAG }}
+        env:
+          - name: DATABASE_DIALECT
+            value: {{ SUPERSET_DB_DIALECT }}
+          - name: DATABASE_HOST 
+            value: {{ SUPERSET_DB_HOST }}
+          - name: DATABASE_PORT
+            value: {{ SUPERSET_DB_PORT }}
+          - name: DATABASE_DB
+            value: {{ SUPERSET_DB_NAME }}
+          - name: DATABASE_PASSWORD
+            value: {{ SUPERSET_DB_PASSWORD }}
+          - name: DATABASE_USER
+            value: {{ SUPERSET_DB_USERNAME }}
+          - name: OPENEDX_MYSQL_HOST
+            value: {{ MYSQL_HOST }}
+          - name: OPENEDX_MYSQL_PORT
+            value: {{ MYSQL_PORT }}
+          - name: OPENEDX_MYSQL_DATABASE
+            value: {{ OPENEDX_MYSQL_DATABASE }}
+          - name: OPENEDX_MYSQL_USERNAME
+            value: {{ OPENEDX_MYSQL_USERNAME }}
+          - name: OPENEDX_MYSQL_PASSWORD
+            value: {{ OPENEDX_MYSQL_PASSWORD }}
+          - name: OAUTH2_CLIENT_ID
+            value: {{ SUPERSET_OAUTH2_CLIENT_ID }}
+          - name: OAUTH2_CLIENT_SECRET
+            value: {{ SUPERSET_OAUTH2_CLIENT_SECRET }}
+          - name: SECRET_KEY
+            value: {{ SUPERSET_SECRET_KEY }}
+          - name: PYTHONPATH
+            value: /app/pythonpath:/app/docker/pythonpath_dev
+          - name: REDIS_HOST
+            value: {{ REDIS_HOST }}
+          - name: REDIS_PORT
+            value: {{ REDIS_PORT }}
+          - name: REDIS_PASSWORD
+            value: {{ REDIS_PASSWORD }}
+          - name: FLASK_ENV
+            value: production
+          - name: SUPERSET_ENV
+            value: production
+          - name: SUPERSET_HOST
+            value: {{ SUPERSET_HOST }}
+          - name: SUPERSET_PORT
+            value: {{ SUPERSET_PORT }}
+          - name: OAUTH2_ACCESS_TOKEN_PATH
+            value: "{{ SUPERSET_OAUTH2_ACCESS_TOKEN_PATH }}"
+          - name: OAUTH2_AUTHORIZE_PATH
+            value: "{{ SUPERSET_OAUTH2_AUTHORIZE_PATH }}"
+          - name: OPENEDX_USERNAME_PATH
+            value: "{{ SUPERSET_OPENEDX_USERNAME_PATH }}"
+          - name: OPENEDX_USER_PROFILE_PATH
+            value: "{{ SUPERSET_OPENEDX_USER_PROFILE_PATH }}"
+          - name: OPENEDX_COURSES_LIST_PATH
+            value: "{{ SUPERSET_OPENEDX_COURSES_LIST_PATH }}"
+          - name: OPENEDX_LMS_ROOT_URL
+            value: "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ LMS_HOST }}"
+        volumeMounts:
+            - mountPath: /app/docker
+              name: docker
+            - mountPath: /app/pythonpath
+              name: pythonpath
+            - mountPath: /app/data
+              name: data
+        restartPolicy: Always
+      volumes:
+        - name: docker
+          configMap:
+            name: superset-docker
+        - name: pythonpath
+          configMap:
+            name: superset-pythonpath
+        - name: data
+          configMap:
+            name: superset-data    
 
 ---
 apiVersion: batch/v1
@@ -27,3 +102,78 @@ spec:
       containers:
       - name: superset-worker
         image: apache/superset:{{ SUPERSET_TAG }}
+        env:
+          - name: DATABASE_DIALECT
+            value: {{ SUPERSET_DB_DIALECT }}
+          - name: DATABASE_HOST 
+            value: {{ SUPERSET_DB_HOST }}
+          - name: DATABASE_PORT
+            value: {{ SUPERSET_DB_PORT }}
+          - name: DATABASE_DB
+            value: {{ SUPERSET_DB_NAME }}
+          - name: DATABASE_PASSWORD
+            value: {{ SUPERSET_DB_PASSWORD }}
+          - name: DATABASE_USER
+            value: {{ SUPERSET_DB_USERNAME }}
+          - name: OPENEDX_MYSQL_HOST
+            value: {{ MYSQL_HOST }}
+          - name: OPENEDX_MYSQL_PORT
+            value: {{ MYSQL_PORT }}
+          - name: OPENEDX_MYSQL_DATABASE
+            value: {{ OPENEDX_MYSQL_DATABASE }}
+          - name: OPENEDX_MYSQL_USERNAME
+            value: {{ OPENEDX_MYSQL_USERNAME }}
+          - name: OPENEDX_MYSQL_PASSWORD
+            value: {{ OPENEDX_MYSQL_PASSWORD }}
+          - name: OAUTH2_CLIENT_ID
+            value: {{ SUPERSET_OAUTH2_CLIENT_ID }}
+          - name: OAUTH2_CLIENT_SECRET
+            value: {{ SUPERSET_OAUTH2_CLIENT_SECRET }}
+          - name: SECRET_KEY
+            value: {{ SUPERSET_SECRET_KEY }}
+          - name: PYTHONPATH
+            value: /app/pythonpath:/app/docker/pythonpath_dev
+          - name: REDIS_HOST
+            value: {{ REDIS_HOST }}
+          - name: REDIS_PORT
+            value: {{ REDIS_PORT }}
+          - name: REDIS_PASSWORD
+            value: {{ REDIS_PASSWORD }}
+          - name: FLASK_ENV
+            value: production
+          - name: SUPERSET_ENV
+            value: production
+          - name: SUPERSET_HOST
+            value: {{ SUPERSET_HOST }}
+          - name: SUPERSET_PORT
+            value: {{ SUPERSET_PORT }}
+          - name: OAUTH2_ACCESS_TOKEN_PATH
+            value: "{{ SUPERSET_OAUTH2_ACCESS_TOKEN_PATH }}"
+          - name: OAUTH2_AUTHORIZE_PATH
+            value: "{{ SUPERSET_OAUTH2_AUTHORIZE_PATH }}"
+          - name: OPENEDX_USERNAME_PATH
+            value: "{{ SUPERSET_OPENEDX_USERNAME_PATH }}"
+          - name: OPENEDX_USER_PROFILE_PATH
+            value: "{{ SUPERSET_OPENEDX_USER_PROFILE_PATH }}"
+          - name: OPENEDX_COURSES_LIST_PATH
+            value: "{{ SUPERSET_OPENEDX_COURSES_LIST_PATH }}"
+          - name: OPENEDX_LMS_ROOT_URL
+            value: "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ LMS_HOST }}"
+        volumeMounts:
+            - mountPath: /app/docker
+              name: docker
+            - mountPath: /app/pythonpath
+              name: pythonpath
+            - mountPath: /app/data
+              name: data
+        restartPolicy: Always
+      volumes:
+        - name: docker
+          configMap:
+            name: superset-docker
+        - name: pythonpath
+          configMap:
+            name: superset-pythonpath
+        - name: data
+          configMap:
+            name: superset-data

--- a/tutorsuperset/patches/k8s-jobs
+++ b/tutorsuperset/patches/k8s-jobs
@@ -14,49 +14,49 @@ spec:
         image: apache/superset:{{ SUPERSET_TAG }}
         env:
           - name: DATABASE_DIALECT
-            value: {{ SUPERSET_DB_DIALECT }}
+            value: "{{ SUPERSET_DB_DIALECT }}"
           - name: DATABASE_HOST 
-            value: {{ SUPERSET_DB_HOST }}
+            value: "{{ SUPERSET_DB_HOST }}"
           - name: DATABASE_PORT
-            value: {{ SUPERSET_DB_PORT }}
+            value: "{{ SUPERSET_DB_PORT }}"
           - name: DATABASE_DB
-            value: {{ SUPERSET_DB_NAME }}
+            value: "{{ SUPERSET_DB_NAME }}"
           - name: DATABASE_PASSWORD
-            value: {{ SUPERSET_DB_PASSWORD }}
+            value: "{{ SUPERSET_DB_PASSWORD }}"
           - name: DATABASE_USER
-            value: {{ SUPERSET_DB_USERNAME }}
+            value: "{{ SUPERSET_DB_USERNAME }}"
           - name: OPENEDX_MYSQL_HOST
-            value: {{ MYSQL_HOST }}
+            value: "{{ MYSQL_HOST }}"
           - name: OPENEDX_MYSQL_PORT
-            value: {{ MYSQL_PORT }}
+            value: "{{ MYSQL_PORT }}"
           - name: OPENEDX_MYSQL_DATABASE
-            value: {{ OPENEDX_MYSQL_DATABASE }}
+            value: "{{ OPENEDX_MYSQL_DATABASE }}"
           - name: OPENEDX_MYSQL_USERNAME
-            value: {{ OPENEDX_MYSQL_USERNAME }}
+            value: "{{ OPENEDX_MYSQL_USERNAME }}"
           - name: OPENEDX_MYSQL_PASSWORD
-            value: {{ OPENEDX_MYSQL_PASSWORD }}
+            value: "{{ OPENEDX_MYSQL_PASSWORD }}"
           - name: OAUTH2_CLIENT_ID
-            value: {{ SUPERSET_OAUTH2_CLIENT_ID }}
+            value: "{{ SUPERSET_OAUTH2_CLIENT_ID }}"
           - name: OAUTH2_CLIENT_SECRET
-            value: {{ SUPERSET_OAUTH2_CLIENT_SECRET }}
+            value: "{{ SUPERSET_OAUTH2_CLIENT_SECRET }}"
           - name: SECRET_KEY
-            value: {{ SUPERSET_SECRET_KEY }}
+            value: "{{ SUPERSET_SECRET_KEY }}"
           - name: PYTHONPATH
-            value: /app/pythonpath:/app/docker/pythonpath_dev
+            value: "/app/pythonpath:/app/docker/pythonpath_dev"
           - name: REDIS_HOST
-            value: {{ REDIS_HOST }}
+            value: "{{ REDIS_HOST }}"
           - name: REDIS_PORT
-            value: {{ REDIS_PORT }}
+            value: "{{ REDIS_PORT }}"
           - name: REDIS_PASSWORD
-            value: {{ REDIS_PASSWORD }}
+            value: "{{ REDIS_PASSWORD }}"
           - name: FLASK_ENV
-            value: production
+            value: "production"
           - name: SUPERSET_ENV
-            value: production
+            value: "production"
           - name: SUPERSET_HOST
-            value: {{ SUPERSET_HOST }}
+            value: "{{ SUPERSET_HOST }}"
           - name: SUPERSET_PORT
-            value: {{ SUPERSET_PORT }}
+            value: "{{ SUPERSET_PORT }}"
           - name: OAUTH2_ACCESS_TOKEN_PATH
             value: "{{ SUPERSET_OAUTH2_ACCESS_TOKEN_PATH }}"
           - name: OAUTH2_AUTHORIZE_PATH
@@ -103,49 +103,49 @@ spec:
         image: apache/superset:{{ SUPERSET_TAG }}
         env:
           - name: DATABASE_DIALECT
-            value: {{ SUPERSET_DB_DIALECT }}
+            value: "{{ SUPERSET_DB_DIALECT }}"
           - name: DATABASE_HOST 
-            value: {{ SUPERSET_DB_HOST }}
+            value: "{{ SUPERSET_DB_HOST }}"
           - name: DATABASE_PORT
-            value: {{ SUPERSET_DB_PORT }}
+            value: "{{ SUPERSET_DB_PORT }}"
           - name: DATABASE_DB
-            value: {{ SUPERSET_DB_NAME }}
+            value: "{{ SUPERSET_DB_NAME }}"
           - name: DATABASE_PASSWORD
-            value: {{ SUPERSET_DB_PASSWORD }}
+            value: "{{ SUPERSET_DB_PASSWORD }}"
           - name: DATABASE_USER
-            value: {{ SUPERSET_DB_USERNAME }}
+            value: "{{ SUPERSET_DB_USERNAME }}"
           - name: OPENEDX_MYSQL_HOST
-            value: {{ MYSQL_HOST }}
+            value: "{{ MYSQL_HOST }}"
           - name: OPENEDX_MYSQL_PORT
-            value: {{ MYSQL_PORT }}
+            value: "{{ MYSQL_PORT }}"
           - name: OPENEDX_MYSQL_DATABASE
-            value: {{ OPENEDX_MYSQL_DATABASE }}
+            value: "{{ OPENEDX_MYSQL_DATABASE }}"
           - name: OPENEDX_MYSQL_USERNAME
-            value: {{ OPENEDX_MYSQL_USERNAME }}
+            value: "{{ OPENEDX_MYSQL_USERNAME }}"
           - name: OPENEDX_MYSQL_PASSWORD
-            value: {{ OPENEDX_MYSQL_PASSWORD }}
+            value: "{{ OPENEDX_MYSQL_PASSWORD }}"
           - name: OAUTH2_CLIENT_ID
-            value: {{ SUPERSET_OAUTH2_CLIENT_ID }}
+            value: "{{ SUPERSET_OAUTH2_CLIENT_ID }}"
           - name: OAUTH2_CLIENT_SECRET
-            value: {{ SUPERSET_OAUTH2_CLIENT_SECRET }}
+            value: "{{ SUPERSET_OAUTH2_CLIENT_SECRET }}"
           - name: SECRET_KEY
-            value: {{ SUPERSET_SECRET_KEY }}
+            value: "{{ SUPERSET_SECRET_KEY }}"
           - name: PYTHONPATH
-            value: /app/pythonpath:/app/docker/pythonpath_dev
+            value: "/app/pythonpath:/app/docker/pythonpath_dev"
           - name: REDIS_HOST
-            value: {{ REDIS_HOST }}
+            value: "{{ REDIS_HOST }}"
           - name: REDIS_PORT
-            value: {{ REDIS_PORT }}
+            value: "{{ REDIS_PORT }}"
           - name: REDIS_PASSWORD
-            value: {{ REDIS_PASSWORD }}
+            value: "{{ REDIS_PASSWORD }}"
           - name: FLASK_ENV
-            value: production
+            value: "production"
           - name: SUPERSET_ENV
-            value: production
+            value: "production"
           - name: SUPERSET_HOST
-            value: {{ SUPERSET_HOST }}
+            value: "{{ SUPERSET_HOST }}"
           - name: SUPERSET_PORT
-            value: {{ SUPERSET_PORT }}
+            value: "{{ SUPERSET_PORT }}"
           - name: OAUTH2_ACCESS_TOKEN_PATH
             value: "{{ SUPERSET_OAUTH2_ACCESS_TOKEN_PATH }}"
           - name: OAUTH2_AUTHORIZE_PATH

--- a/tutorsuperset/patches/k8s-jobs
+++ b/tutorsuperset/patches/k8s-jobs
@@ -76,7 +76,6 @@ spec:
               name: pythonpath
             - mountPath: /app/data
               name: data
-        restartPolicy: Always
       volumes:
         - name: docker
           configMap:
@@ -166,7 +165,6 @@ spec:
               name: pythonpath
             - mountPath: /app/data
               name: data
-        restartPolicy: Always
       volumes:
         - name: docker
           configMap:

--- a/tutorsuperset/patches/k8s-jobs
+++ b/tutorsuperset/patches/k8s-jobs
@@ -12,3 +12,18 @@ spec:
       containers:
       - name: superset
         image: apache/superset:{{ SUPERSET_TAG }}
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: superset-worker-jon
+  labels:
+    app.kubernetes.io/component: job
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: superset-worker
+        image: apache/superset:{{ SUPERSET_TAG }}

--- a/tutorsuperset/patches/k8s-services
+++ b/tutorsuperset/patches/k8s-services
@@ -12,18 +12,3 @@ spec:
       protocol: TCP
   selector:
     app.kubernetes.io/name: superset
-
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: superset-worker
-  labels:
-    app.kubernetes.io/name: superset-worker
-spec:
-  type: ClusterIP
-  ports:
-    - port: {{ SUPERSET_PORT }}
-      protocol: TCP
-  selector:
-    app.kubernetes.io/name: superset-worker

--- a/tutorsuperset/patches/k8s-services
+++ b/tutorsuperset/patches/k8s-services
@@ -1,0 +1,29 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: superset
+  labels:
+    app.kubernetes.io/name: superset
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ SUPERSET_PORT }}
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: superset
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: superset-worker
+  labels:
+    app.kubernetes.io/name: superset-worker
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ SUPERSET_PORT }}
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: superset-worker

--- a/tutorsuperset/patches/kustomization-configmapgenerator
+++ b/tutorsuperset/patches/kustomization-configmapgenerator
@@ -2,6 +2,9 @@
   files:
     - plugins/superset/apps/docker/docker-bootstrap.sh
     - plugins/superset/apps/docker/requirements-local.txt
+  options:
+    labels:
+        app.kubernetes.io/name: superset
 
 - name: superset-pythonpath
   files:
@@ -9,7 +12,13 @@
     - plugins/superset/apps/pythonpath/openedx_sso_security_manager.py
     - plugins/superset/apps/pythonpath/superset_config_docker.py
     - plugins/superset/apps/pythonpath/superset_config.py
+  options:
+    labels:
+        app.kubernetes.io/name: superset
 
 - name: superset-data
   files:
     - plugins/superset/apps/data/roles.json
+  options:
+    labels:
+        app.kubernetes.io/name: superset

--- a/tutorsuperset/patches/kustomization-configmapgenerator
+++ b/tutorsuperset/patches/kustomization-configmapgenerator
@@ -1,0 +1,15 @@
+- name: superset-docker
+  files:
+    - plugins/superset/apps/docker/docker-bootstrap.sh
+    - plugins/superset/apps/docker/requirements-local.txt
+
+- name: superset-pythonpath
+  files:
+    - plugins/superset/apps/pythonpath/openedx_jinja_filters.py
+    - plugins/superset/apps/pythonpath/openedx_sso_security_manager.py
+    - plugins/superset/apps/pythonpath/superset_config_docker.py
+    - plugins/superset/apps/pythonpath/superset_config.py
+
+- name: superset-data
+  files:
+    - plugins/superset/apps/data/roles.json

--- a/tutorsuperset/plugin.py
+++ b/tutorsuperset/plugin.py
@@ -17,7 +17,7 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         # Each new setting is a pair: (setting_name, default_value).
         # Prefix your setting names with 'SUPERSET_'.
         ("SUPERSET_VERSION", __version__),
-        ("SUPERSET_TAG", "2.0.1"),
+        ("SUPERSET_TAG", "2.1.0"),
         ("SUPERSET_HOST", "superset.{{ LMS_HOST }}"),
         ("SUPERSET_PORT", "8088"),
         ("SUPERSET_DB_DIALECT", "mysql"),

--- a/tutorsuperset/templates/superset/apps/pythonpath/superset_config.py
+++ b/tutorsuperset/templates/superset/apps/pythonpath/superset_config.py
@@ -49,6 +49,7 @@ def get_env_variable(var_name: str, default: Optional[str] = None) -> str:
             )
             raise EnvironmentError(error_msg)
 
+SECRET_KEY = os.environ["SECRET_KEY"]
 
 DATABASE_DIALECT = get_env_variable("DATABASE_DIALECT")
 DATABASE_USER = get_env_variable("DATABASE_USER")

--- a/tutorsuperset/templates/superset/apps/pythonpath/superset_config.py
+++ b/tutorsuperset/templates/superset/apps/pythonpath/superset_config.py
@@ -30,7 +30,7 @@ import os
 from datetime import timedelta
 from typing import Optional
 
-from cachelib.file import FileSystemCache
+from cachelib.redis import RedisCache
 from celery.schedules import crontab
 
 from superset.superset_typing import CacheConfig
@@ -71,8 +71,9 @@ REDIS_HOST = get_env_variable("REDIS_HOST")
 REDIS_PORT = get_env_variable("REDIS_PORT")
 REDIS_CELERY_DB = get_env_variable("REDIS_CELERY_DB", "0")
 REDIS_RESULTS_DB = get_env_variable("REDIS_RESULTS_DB", "1")
+REDIS_PASSWORD = get_env_variable("REDIS_PASSWORD", "")
 
-RESULTS_BACKEND = FileSystemCache("/app/superset_home/sqllab")
+RESULTS_BACKEND = RedisCache(host=REDIS_HOST, port=REDIS_PORT, password=REDIS_PASSWORD, db=REDIS_RESULTS_DB, key_prefix='superset_results')
 
 CACHE_CONFIG = {
     "CACHE_TYPE": "redis",
@@ -80,6 +81,7 @@ CACHE_CONFIG = {
     "CACHE_KEY_PREFIX": "superset_",
     "CACHE_REDIS_HOST": REDIS_HOST,
     "CACHE_REDIS_PORT": REDIS_PORT,
+    'CACHE_REDIS_PASSWORD': REDIS_PASSWORD,
     "CACHE_REDIS_DB": REDIS_RESULTS_DB,
 }
 DATA_CACHE_CONFIG = CACHE_CONFIG


### PR DESCRIPTION
## Description

This PR adds the necessary files to make this plugin compatible with k8s. This PR also fixes an issue in which the REDIS_PASSWORD environment variable was not taken as part of the superset cache.

It also sets the RESULTS_BACKEND as REDIS.

### Notes:

I didn't include the celery heartbeat. Please let me know if it will be necessary