### PR TITLE
fix: enable volumes for superset jobs

### DIFF
--- a/tutorsuperset/patches/k8s-jobs
+++ b/tutorsuperset/patches/k8s-jobs
@@ -69,6 +69,23 @@ spec:
             value: "{{ SUPERSET_OPENEDX_COURSES_LIST_PATH }}"
           - name: OPENEDX_LMS_ROOT_URL
             value: "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ LMS_HOST }}" 
+        volumeMounts:
+          - mountPath: /app/docker
+            name: docker
+          - mountPath: /app/pythonpath
+            name: pythonpath
+          - mountPath: /app/data
+            name: data
+      volumes:
+        - name: docker
+          configMap:
+            name: superset-docker
+        - name: pythonpath
+          configMap:
+            name: superset-pythonpath
+        - name: data
+          configMap:
+            name: superset-data
 
 ---
 apiVersion: batch/v1
@@ -141,3 +158,20 @@ spec:
             value: "{{ SUPERSET_OPENEDX_COURSES_LIST_PATH }}"
           - name: OPENEDX_LMS_ROOT_URL
             value: "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ LMS_HOST }}"
+        volumeMounts:
+          - mountPath: /app/docker
+            name: docker
+          - mountPath: /app/pythonpath
+            name: pythonpath
+          - mountPath: /app/data
+            name: data
+      volumes:
+        - name: docker
+          configMap:
+            name: superset-docker
+        - name: pythonpath
+          configMap:
+            name: superset-pythonpath
+        - name: data
+          configMap:
+            name: superset-data

--- a/tutorsuperset/plugin.py
+++ b/tutorsuperset/plugin.py
@@ -17,7 +17,7 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         # Each new setting is a pair: (setting_name, default_value).
         # Prefix your setting names with 'SUPERSET_'.
         ("SUPERSET_VERSION", __version__),
-        ("SUPERSET_TAG", "2.1.0"),
+        ("SUPERSET_TAG", "2.0.1"),
         ("SUPERSET_HOST", "superset.{{ LMS_HOST }}"),
         ("SUPERSET_PORT", "8088"),
         ("SUPERSET_DB_DIALECT", "mysql"),

--- a/tutorsuperset/plugin.py
+++ b/tutorsuperset/plugin.py
@@ -37,6 +37,7 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         ("SUPERSET_ADMIN_EMAIL", "admin@openedx.org"),
         # Set to 0 to have no row limit.
         ("SUPERSET_ROW_LIMIT", 100_000),
+        ("SUPERSET_SENTRY_DSN", ""),
     ]
 )
 

--- a/tutorsuperset/templates/superset/apps/docker/requirements-local.txt
+++ b/tutorsuperset/templates/superset/apps/docker/requirements-local.txt
@@ -1,3 +1,4 @@
 authlib  # OAuth2
 mysqlclient
 clickhouse-connect>0.5,<0.6
+sentry-sdk[flask]

--- a/tutorsuperset/templates/superset/apps/pythonpath/superset_config.py
+++ b/tutorsuperset/templates/superset/apps/pythonpath/superset_config.py
@@ -132,6 +132,17 @@ WEBDRIVER_BASEURL_USER_FRIENDLY = WEBDRIVER_BASEURL
 
 SQLLAB_CTAS_NO_LIMIT = True
 
+
+{% if SUPERSET_SENTRY_DSN %}
+import sentry_sdk
+from sentry_sdk.integrations.flask import FlaskIntegration
+
+sentry_sdk.init(
+    dsn='{{ SUPERSET_SENTRY_DSN }}',
+    integrations=[FlaskIntegration()],
+)
+{% endif %}
+
 #
 # Optionally import superset_config_docker.py (which will have been included on
 # the PYTHONPATH) in order to allow for local settings to be overridden


### PR DESCRIPTION
## Description

This PR fixes an issue in which the superset job was unable to run because it doesn't had the necessary files.

It also adds support to integrate sentry with superset. 