### PR TITLE
feat: add config to set talisman config

### DIFF
--- a/tutorsuperset/plugin.py
+++ b/tutorsuperset/plugin.py
@@ -55,6 +55,23 @@ hooks.Filters.CONFIG_UNIQUE.add_items(
         ("SUPERSET_ADMIN_USERNAME", "{{ 12|random_string }}"),
         ("SUPERSET_ADMIN_PASSWORD", "{{ 24|random_string }}"),
         ("RUN_SUPERSET", True),
+        (
+            "SUPERSET_TALISMAN_CONFIG",
+            {
+                "content_security_policy": {
+                    "default-src": ["'self'", "'unsafe-inline'", "'unsafe-eval'"],
+                    "img-src": ["'self'", "data:"],
+                    "worker-src": ["'self'", "blob:"],
+                    "connect-src": [
+                        "'self'",
+                        "https://api.mapbox.com",
+                        "https://events.mapbox.com",
+                    ],
+                    "object-src": "'none'",
+                }
+            },
+        ),
+        ("SUPERSET_TALISMAN_ENABLED", True),
     ]
 )
 

--- a/tutorsuperset/templates/superset/apps/pythonpath/superset_config.py
+++ b/tutorsuperset/templates/superset/apps/pythonpath/superset_config.py
@@ -143,6 +143,10 @@ sentry_sdk.init(
 )
 {% endif %}
 
+{% if ENABLE_HTTPS %}
+TALISMAN_ENABLED = {{SUPERSET_TALISMAN_ENABLED}}
+TALISMAN_CONFIG = {{SUPERSET_TALISMAN_CONFIG}}
+{% endif %}
 #
 # Optionally import superset_config_docker.py (which will have been included on
 # the PYTHONPATH) in order to allow for local settings to be overridden


### PR DESCRIPTION
## Description

This PR adds two new settings:

- `SUPERSET_TALISMAN_CONFIG` to allow site operators to adapt it to their needs.
- `SUPERSET_TALISMAN_ENABLED` to enable CSP

It solves: #21 

Keep in mind that I've added those settings as `CONFIG_UNIQUE` so those values will be reflected on the **config.yml**:


```yaml
SUPERSET_TALISMAN_CONFIG:
  content_security_policy:
    connect-src:
    - '''self'''
    - https://api.mapbox.com
    - https://events.mapbox.com
    default-src:
    - '''self'''
    - '''unsafe-inline'''
    - '''unsafe-eval'''
    img-src:
    - '''self'''
    - 'data:'
    object-src: '''none'''
    worker-src:
    - '''self'''
    - 'blob:'
SUPERSET_TALISMAN_ENABLED: true
```