### PR TITLE
fix: Add dependencies on MySQL and Redis based on the configuration variables

### DIFF
--- a/tutorsuperset/patches/local-docker-compose-dev-services
+++ b/tutorsuperset/patches/local-docker-compose-dev-services
@@ -6,8 +6,8 @@ superset:
   ports:
     - 8088:{{ SUPERSET_PORT }}
   depends_on:
-    - mysql
-    - redis
+    {% if RUN_MYSQL %}- mysql{% endif %}
+    {% if RUN_REDIS %}- redis{% endif %}
     - superset-worker
     - superset-worker-beat
 
@@ -18,8 +18,8 @@ superset-worker:
   healthcheck:
     test: ["CMD-SHELL", "celery inspect ping -A superset.tasks.celery_app:app -d celery@$$HOSTNAME"]
   depends_on:
-    - mysql
-    - redis
+    {% if RUN_MYSQL %}- mysql{% endif %}
+    {% if RUN_REDIS %}- redis{% endif %}
 
 superset-worker-beat:
   {% include 'base-docker-compose-services' %}
@@ -28,6 +28,6 @@ superset-worker-beat:
   healthcheck:
     disable: true
   depends_on:
-    - mysql
-    - redis
+    {% if RUN_MYSQL %}- mysql{% endif %}
+    {% if RUN_REDIS %}- redis{% endif %}
 {% endif %}

--- a/tutorsuperset/patches/local-docker-compose-jobs-services
+++ b/tutorsuperset/patches/local-docker-compose-jobs-services
@@ -3,7 +3,7 @@ superset-job:
   {% include 'base-docker-compose-services' %}
     OPENEDX_LMS_ROOT_URL: "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ LMS_HOST }}"
   depends_on:
-    - mysql
-    - redis
+    {% if RUN_MYSQL %}- mysql{% endif %}
+    {% if RUN_REDIS %}- redis{% endif %}
     - superset
 {% endif %}

--- a/tutorsuperset/patches/local-docker-compose-services
+++ b/tutorsuperset/patches/local-docker-compose-services
@@ -6,8 +6,8 @@ superset:
   ports:
     - 8088:{{ SUPERSET_PORT }}
   depends_on:
-    - mysql
-    - redis
+    {% if RUN_MYSQL %}- mysql{% endif %}
+    {% if RUN_REDIS %}- redis{% endif %}
     - superset-worker
     - superset-worker-beat
 
@@ -18,8 +18,8 @@ superset-worker:
   healthcheck:
     test: ["CMD-SHELL", "celery inspect ping -A superset.tasks.celery_app:app -d celery@$$HOSTNAME"]
   depends_on:
-    - mysql
-    - redis
+    {% if RUN_MYSQL %}- mysql{% endif %}
+    {% if RUN_REDIS %}- redis{% endif %}
 
 superset-worker-beat:
   {% include 'base-docker-compose-services' %}
@@ -28,6 +28,6 @@ superset-worker-beat:
   healthcheck:
     disable: true
   depends_on:
-    - mysql
-    - redis
+    {% if RUN_MYSQL %}- mysql{% endif %}
+    {% if RUN_REDIS %}- redis{% endif %}
 {% endif %}


### PR DESCRIPTION
This PR adds conditional dependencies for the depends_on section in the Docker Compose file. The dependencies are based on the values of two variables, RUN_MYSQL and RUN_REDIS. If RUN_MYSQL is true, the mysql service will be included as a dependency. Similarly, if RUN_REDIS is true, the redis service will be included.

This change enhances the flexibility and modularity of the project, allowing users to selectively include or exclude the MySQL and Redis services based on their requirements. It simplifies the configuration process and optimizes resource allocation by only starting the necessary services.

Please review and merge this PR if it aligns with the project's goals and requirements.

Thank you!